### PR TITLE
Allow ubl version id to be null

### DIFF
--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -1,5 +1,4 @@
 # Changelog for version [next-release]
 
 ### New features & improvements
-
-### Breaking changes
+* Added new ContractDocumentReference class & tag cac:ContractDocumentReference to Invoice

--- a/changelog/next-release.md
+++ b/changelog/next-release.md
@@ -2,3 +2,4 @@
 
 ### New features & improvements
 * Added new ContractDocumentReference class & tag cac:ContractDocumentReference to Invoice
+* Remove duplicate validation for `id` on invoice

--- a/src/ContractDocumentReference.php
+++ b/src/ContractDocumentReference.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class ContractDocumentReference implements XmlSerializable
+{
+    private $id;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return ContractDocumentReference
+     */
+    public function setId(string $id): ContractDocumentReference
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer)
+    {
+        if ($this->id !== null) {
+            $writer->write([ Schema::CBC . 'ID' => $this->id ]);
+        }
+    }
+}

--- a/src/CreditNoteLine.php
+++ b/src/CreditNoteLine.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class CreditNoteLine implements XmlSerializable
+{
+    private $id;
+    private $creditedQuantity;
+    private $lineExtensionAmount;
+    private $unitCode = 'MON';
+    private $taxTotal;
+    private $invoicePeriod;
+    private $note;
+    private $item;
+    private $price;
+    private $accountingCostCode;
+
+    /**
+     * @return string
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return CreditNoteLine
+     */
+    public function setId(?string $id): CreditNoteLine
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getcreditedQuantity(): ?float
+    {
+        return $this->creditedQuantity;
+    }
+
+    /**
+     * @param float $creditedQuantity
+     * @return CreditNoteLine
+     */
+    public function setcreditedQuantity(?float $creditedQuantity): CreditNoteLine
+    {
+        $this->creditedQuantity = $creditedQuantity;
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getLineExtensionAmount(): ?float
+    {
+        return $this->lineExtensionAmount;
+    }
+
+    /**
+     * @param float $lineExtensionAmount
+     * @return CreditNoteLine
+     */
+    public function setLineExtensionAmount(?float $lineExtensionAmount): CreditNoteLine
+    {
+        $this->lineExtensionAmount = $lineExtensionAmount;
+        return $this;
+    }
+
+    /**
+     * @return TaxTotal
+     */
+    public function getTaxTotal(): ?TaxTotal
+    {
+        return $this->taxTotal;
+    }
+
+    /**
+     * @param TaxTotal $taxTotal
+     * @return CreditNoteLine
+     */
+    public function setTaxTotal(?TaxTotal $taxTotal): CreditNoteLine
+    {
+        $this->taxTotal = $taxTotal;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    /**
+     * @param string $note
+     * @return CreditNoteLine
+     */
+    public function setNote(?string $note): CreditNoteLine
+    {
+        $this->note = $note;
+        return $this;
+    }
+
+    /**
+     * @return InvoicePeriod
+     */
+    public function getInvoicePeriod(): ?InvoicePeriod
+    {
+        return $this->invoicePeriod;
+    }
+
+    /**
+     * @param InvoicePeriod $invoicePeriod
+     * @return CreditNoteLine
+     */
+    public function setInvoicePeriod(?InvoicePeriod $invoicePeriod)
+    {
+        $this->invoicePeriod = $invoicePeriod;
+        return $this;
+    }
+
+    /**
+     * @return Item
+     */
+    public function getItem(): ?Item
+    {
+        return $this->item;
+    }
+
+    /**
+     * @param Item $item
+     * @return CreditNoteLine
+     */
+    public function setItem(Item $item): CreditNoteLine
+    {
+        $this->item = $item;
+        return $this;
+    }
+
+    /**
+     * @return Price
+     */
+    public function getPrice(): ?Price
+    {
+        return $this->price;
+    }
+
+    /**
+     * @param Price $price
+     * @return CreditNoteLine
+     */
+    public function setPrice(?Price $price): CreditNoteLine
+    {
+        $this->price = $price;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUnitCode(): ?string
+    {
+        return $this->unitCode;
+    }
+
+    /**
+     * @param string $unitCode
+     * @return CreditNoteLine
+     */
+    public function setUnitCode(?string $unitCode): CreditNoteLine
+    {
+        $this->unitCode = $unitCode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountingCostCode(): ?string
+    {
+        return $this->accountingCostCode;
+    }
+
+    /**
+     * @param string $accountingCostCode
+     * @return CreditNoteLine
+     */
+    public function setAccountingCostCode(?string $accountingCostCode): CreditNoteLine
+    {
+        $this->accountingCostCode = $accountingCostCode;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer)
+    {
+        $writer->write([
+            Schema::CBC . 'ID' => $this->id
+        ]);
+
+        if (!empty($this->getNote())) {
+            $writer->write([
+                Schema::CBC . 'Note' => $this->getNote()
+            ]);
+        }
+
+        $writer->write([
+            [
+                'name' => Schema::CBC . 'CreditedQuantity',
+                'value' => number_format($this->creditedQuantity, 2, '.', ''),
+                'attributes' => [
+                    'unitCode' => $this->unitCode
+                ]
+            ],
+            [
+                'name' => Schema::CBC . 'LineExtensionAmount',
+                'value' => number_format($this->lineExtensionAmount, 2, '.', ''),
+                'attributes' => [
+                    'currencyID' => Generator::$currencyID
+                ]
+            ]
+        ]);
+        if ($this->accountingCostCode !== null) {
+            $writer->write([
+                Schema::CBC . 'AccountingCostCode' => $this->accountingCostCode
+            ]);
+        }
+        if ($this->invoicePeriod !== null) {
+            $writer->write([
+                Schema::CAC . 'InvoicePeriod' => $this->invoicePeriod
+            ]);
+        }
+        if ($this->taxTotal !== null) {
+            $writer->write([
+                Schema::CAC . 'TaxTotal' => $this->taxTotal
+            ]);
+        }
+        $writer->write([
+            Schema::CAC . 'Item' => $this->item,
+        ]);
+
+        if ($this->price !== null) {
+            $writer->write([
+                Schema::CAC . 'Price' => $this->price
+            ]);
+        } else {
+            $writer->write([
+                Schema::CAC . 'TaxScheme' => null,
+            ]);
+        }
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,7 +8,7 @@ class Generator
 {
     public static $currencyID;
 
-    public static function invoice(Invoice $invoice, $currencyId = 'EUR')
+    public static function invoice(Invoice $invoice, $currencyId = 'EUR', $invoiceType)
     {
         self::$currencyID = $currencyId;
 
@@ -20,7 +20,15 @@ class Generator
             'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' => 'cac'
         ];
 
-        return $xmlService->write('Invoice', [
+        if ($invoiceType === 'CreditNote')
+            $xmlService->namespaceMap = [
+                'urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2' => '',
+                'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2' => 'cbc',
+                'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' => 'cac'
+            ];
+        }
+
+        return $xmlService->write($invoiceType, [
             $invoice
         ]);
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,7 +8,7 @@ class Generator
 {
     public static $currencyID;
 
-    public static function invoice(Invoice $invoice, $currencyId = 'EUR', $invoiceType)
+    public static function invoice(Invoice $invoice, $currencyId = 'EUR')
     {
         self::$currencyID = $currencyId;
 
@@ -20,15 +20,24 @@ class Generator
             'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' => 'cac'
         ];
 
-        if ($invoiceType === 'CreditNote')
-            $xmlService->namespaceMap = [
-                'urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2' => '',
-                'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2' => 'cbc',
-                'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' => 'cac'
-            ];
-        }
+        return $xmlService->write('Invoice', [
+            $invoice
+        ]);
+    }
 
-        return $xmlService->write($invoiceType, [
+    public static function creditNote(Invoice $invoice, $currencyId = 'EUR')
+    {
+        self::$currencyID = $currencyId;
+
+        $xmlService = new Service();
+
+        $xmlService->namespaceMap = [
+            'urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2' => '',
+            'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2' => 'cbc',
+            'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2' => 'cac'
+        ];
+
+        return $xmlService->write('CreditNote', [
             $invoice
         ]);
     }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -35,7 +35,7 @@ class Invoice implements XmlSerializable
     private $invoicePeriod;
     private $delivery;
     private $orderReference;
-
+    private $contractDocumentReference;
 
     /**
      * @return string
@@ -474,6 +474,24 @@ class Invoice implements XmlSerializable
     }
 
     /**
+     * @return ContractDocumentReference
+     */
+    public function getContractDocumentReference(): ?ContractDocumentReference
+    {
+        return $this->contractDocumentReference;
+    }
+
+    /**
+     * @param string $ContractDocumentReference
+     * @return Invoice
+     */
+    public function setContractDocumentReference(ContractDocumentReference $contractDocumentReference): Invoice
+    {
+        $this->contractDocumentReference = $contractDocumentReference;
+        return $this;
+    }
+
+    /**
      * The validate function that is called during xml writing to valid the data of the object.
      *
      * @return void
@@ -576,6 +594,12 @@ class Invoice implements XmlSerializable
         if ($this->buyerReference != null) {
             $writer->write([
                 Schema::CBC . 'BuyerReference' => $this->buyerReference
+            ]);
+        }
+
+        if ($this->contractDocumentReference !== null) {
+            $writer->write([
+                Schema::CAC . 'ContractDocumentReference' => $this->contractDocumentReference,
             ]);
         }
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -503,10 +503,6 @@ class Invoice implements XmlSerializable
             throw new InvalidArgumentException('Missing invoice id');
         }
 
-        if ($this->id === null) {
-            throw new InvalidArgumentException('Missing invoice id');
-        }
-
         if (!$this->issueDate instanceof DateTime) {
             throw new InvalidArgumentException('Invalid invoice issueDate');
         }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 
 class Invoice implements XmlSerializable
 {
-    private $UBLVersionID = '2.1';
+    private $UBLVersionID;
     private $customizationID = '1.0';
     private $id;
     private $copyIndicator;
@@ -568,8 +568,13 @@ class Invoice implements XmlSerializable
     {
         $this->validate();
 
+        if ($this->UBLVersionID !== null) {
+            $writer->write([
+                Schema::CBC . 'UBLVersionID' => $this->UBLVersionID,
+            ]);
+        }
+
         $writer->write([
-            Schema::CBC . 'UBLVersionID' => $this->UBLVersionID,
             Schema::CBC . 'CustomizationID' => $this->customizationID,
             Schema::CBC . 'ID' => $this->id
         ]);

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -15,7 +15,8 @@ class Invoice implements XmlSerializable
     private $id;
     private $copyIndicator;
     private $issueDate;
-    private $invoiceTypeCode = InvoiceTypeCode::INVOICE;
+    private $invoiceTypeCode;
+    private $creditNoteTypeCode;
     private $note;
     private $taxPointDate;
     private $dueDate;
@@ -164,6 +165,25 @@ class Invoice implements XmlSerializable
     public function setInvoiceTypeCode(string $invoiceTypeCode): Invoice
     {
         $this->invoiceTypeCode = $invoiceTypeCode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreditNoteTypeCode(): ?string
+    {
+        return $this->creditNoteTypeCode;
+    }
+
+    /**
+     * @param string $creditNoteTypeCode
+     * See also: src/InvoiceTypeCode.php
+     * @return Invoice
+     */
+    public function setCreditNoteTypeCode(string $creditNoteTypeCode): Invoice
+    {
+        $this->creditNoteTypeCode = $creditNoteTypeCode;
         return $this;
     }
 
@@ -507,20 +527,12 @@ class Invoice implements XmlSerializable
             throw new InvalidArgumentException('Invalid invoice issueDate');
         }
 
-        if ($this->invoiceTypeCode === null) {
-            throw new InvalidArgumentException('Missing invoice invoiceTypeCode');
-        }
-
         if ($this->accountingSupplierParty === null) {
             throw new InvalidArgumentException('Missing invoice accountingSupplierParty');
         }
 
         if ($this->accountingCustomerParty === null) {
             throw new InvalidArgumentException('Missing invoice accountingCustomerParty');
-        }
-
-        if ($this->invoiceLines === null) {
-            throw new InvalidArgumentException('Missing invoice lines');
         }
 
         if ($this->legalMonetaryTotal === null) {
@@ -562,6 +574,12 @@ class Invoice implements XmlSerializable
         if ($this->invoiceTypeCode !== null) {
             $writer->write([
                 Schema::CBC . 'InvoiceTypeCode' => $this->invoiceTypeCode
+            ]);
+        }
+
+        if ($this->creditNoteTypeCode !== null) {
+            $writer->write([
+                Schema::CBC . 'CreditNoteTypeCode' => $this->creditNoteTypeCode
             ]);
         }
 
@@ -669,10 +687,12 @@ class Invoice implements XmlSerializable
             Schema::CAC . 'LegalMonetaryTotal' => $this->legalMonetaryTotal
         ]);
 
-        foreach ($this->invoiceLines as $invoiceLine) {
-            $writer->write([
-                Schema::CAC . 'InvoiceLine' => $invoiceLine
-            ]);
+        if ($this->invoiceLines !== null) {
+            foreach ($this->invoiceLines as $invoiceLine) {
+                $writer->write([
+                    Schema::CAC . 'InvoiceLine' => $invoiceLine
+                ]);
+            }
         }
     }
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -28,6 +28,7 @@ class Invoice implements XmlSerializable
     private $taxTotal;
     private $legalMonetaryTotal;
     private $invoiceLines;
+    private $creditNoteLines;
     private $allowanceCharges;
     private $additionalDocumentReference;
     private $documentCurrencyCode = 'EUR';
@@ -368,6 +369,24 @@ class Invoice implements XmlSerializable
     }
 
     /**
+     * @return CreditNoteLine[]
+     */
+    public function getCreditNoteLines(): ?array
+    {
+        return $this->creditNoteLines;
+    }
+
+    /**
+     * @param CreditNoteLine[] $creditNoteLines
+     * @return Invoice
+     */
+    public function setCreditNoteLines(array $creditNoteLines): Invoice
+    {
+        $this->creditNoteLines = $creditNoteLines;
+        return $this;
+    }
+
+    /**
      * @return AllowanceCharge[]
      */
     public function getAllowanceCharges(): ?array
@@ -691,6 +710,14 @@ class Invoice implements XmlSerializable
             foreach ($this->invoiceLines as $invoiceLine) {
                 $writer->write([
                     Schema::CAC . 'InvoiceLine' => $invoiceLine
+                ]);
+            }
+        }
+
+        if ($this->creditNoteLines !== null) {
+            foreach ($this->creditNoteLines as $creditNoteLine) {
+                $writer->write([
+                    Schema::CAC . 'CreditNoteLine' => $creditNoteLine
                 ]);
             }
         }

--- a/src/Party.php
+++ b/src/Party.php
@@ -149,6 +149,12 @@ class Party implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
+        if ($this->partyIdentification !== null) {
+            $writer->write([
+                Schema::CAC . 'PartyIdentification' => $this->partyIdentification
+            ]);
+        }
+
         $writer->write([
             Schema::CAC . 'PartyName' => [
                 Schema::CBC . 'Name' => $this->name
@@ -177,12 +183,6 @@ class Party implements XmlSerializable
         if ($this->contact !== null) {
             $writer->write([
                 Schema::CAC . 'Contact' => $this->contact
-            ]);
-        }
-
-        if ($this->partyIdentification !== null) {
-            $writer->write([
-                Schema::CAC . 'PartyIdentification' => $this->partyIdentification
             ]);
         }
     }

--- a/src/Party.php
+++ b/src/Party.php
@@ -13,6 +13,7 @@ class Party implements XmlSerializable
     private $contact;
     private $partyTaxScheme;
     private $legalEntity;
+    private $partyIdentification;
 
     /**
      * @return string
@@ -123,6 +124,24 @@ class Party implements XmlSerializable
     }
 
     /**
+     * @return PartyIdentification
+     */
+    public function getPartyIdentification(): ?PartyIdentification
+    {
+        return $this->partyIdentification;
+    }
+
+    /**
+     * @param PartyIdentification $partyIdentification
+     * @return Party
+     */
+    public function setPartyIdentification(?PartyIdentification $partyIdentification): Party
+    {
+        $this->partyIdentification = $partyIdentification;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      *
      * @param Writer $writer
@@ -158,6 +177,12 @@ class Party implements XmlSerializable
         if ($this->contact !== null) {
             $writer->write([
                 Schema::CAC . 'Contact' => $this->contact
+            ]);
+        }
+
+        if ($this->partyIdentification !== null) {
+            $writer->write([
+                Schema::CAC . 'PartyIdentification' => $this->partyIdentification
             ]);
         }
     }

--- a/src/PartyIdentification.php
+++ b/src/PartyIdentification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class PartyIdentification implements XmlSerializable
+{
+    private $id;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return PartyIdentification
+     */
+    public function setId(string $id): PartyIdentification
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer)
+    {
+        if ($this->id !== null) {
+            $writer->write([ Schema::CBC . 'ID' => $this->id ]);
+        }
+    }
+}

--- a/src/PartyIdentification.php
+++ b/src/PartyIdentification.php
@@ -8,6 +8,7 @@ use Sabre\Xml\XmlSerializable;
 class PartyIdentification implements XmlSerializable
 {
     private $id;
+    private $schemeID = 'SEPA';
 
     /**
      * @return string
@@ -28,6 +29,24 @@ class PartyIdentification implements XmlSerializable
     }
 
     /**
+     * @return string
+     */
+    public function getSchemeID(): ?string
+    {
+        return $this->schemeID;
+    }
+
+    /**
+     * @param string $schemeID
+     * @return PartyIdentification
+     */
+    public function setSchemeID(?string $schemeID): PartyIdentification
+    {
+        $this->schemeID = $schemeID;
+        return $this;
+    }
+
+    /**
      * The xmlSerialize method is called during xml writing.
      *
      * @param Writer $writer
@@ -35,8 +54,12 @@ class PartyIdentification implements XmlSerializable
      */
     public function xmlSerialize(Writer $writer)
     {
-        if ($this->id !== null) {
-            $writer->write([ Schema::CBC . 'ID' => $this->id ]);
-        }
+        $writer->write([
+            'name' => Schema::CBC . 'ID',
+            'value' => $this->id,
+            'attributes' => [
+                'schemeID' => $this->schemeID
+            ]
+        ]);
     }
 }

--- a/src/PayerFinancialAccount.php
+++ b/src/PayerFinancialAccount.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class PayerFinancialAccount implements XmlSerializable
+{
+    private $id;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return PayerFinancialAccount
+     */
+    public function setId(string $id): PayerFinancialAccount
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer)
+    {
+        if ($this->id !== null) {
+            $writer->write([ Schema::CBC . 'ID' => $this->id ]);
+        }
+    }
+}

--- a/src/PaymentMandate.php
+++ b/src/PaymentMandate.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace NumNum\UBL;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class PaymentMandate implements XmlSerializable
+{
+    private $id;
+    private $payerFinancialAccount;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return PaymentMandate
+     */
+    public function setId(string $id): PaymentMandate
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return PayerFinancialAccount
+     */
+    public function getPayerFinancialAccount(): PayerFinancialAccount
+    {
+        return $this->payerFinancialAccount;
+    }
+
+    /**
+     * @param PayerFinancialAccount $payerFinancialAccount
+     * @return Party
+     */
+    public function setPayerFinancialAccount(PayerFinancialAccount $payerFinancialAccount): PaymentMandate
+    {
+        $this->payerFinancialAccount = $payerFinancialAccount;
+        return $this;
+    }
+
+    /**
+     * The xmlSerialize method is called during xml writing.
+     *
+     * @param Writer $writer
+     * @return void
+     */
+    public function xmlSerialize(Writer $writer)
+    {
+        $writer->write([
+            Schema::CBC . 'ID' => $this->id
+        ]);
+
+        $writer->write([
+            Schema::CAC . 'PayerFinancialAccount' => $this->payerFinancialAccount
+        ]);
+    }
+}

--- a/src/PaymentMeans.php
+++ b/src/PaymentMeans.php
@@ -18,6 +18,7 @@ class PaymentMeans implements XmlSerializable
     private $instructionNote;
     private $paymentId;
     private $payeeFinancialAccount;
+    private $paymentMandate;
 
     /**
      * @return string
@@ -130,6 +131,24 @@ class PaymentMeans implements XmlSerializable
         return $this;
     }
 
+    /**
+     * @return mixed
+     */
+    public function getPaymentMandate(): ?PaymentMandate
+    {
+        return $this->paymentMandate;
+    }
+
+    /**
+     * @param mixed $paymentMandate
+     * @return PaymentMeans
+     */
+    public function setPaymentMandate(?PaymentMandate $paymentMandate): PaymentMeans
+    {
+        $this->paymentMandate = $paymentMandate;
+        return $this;
+    }
+
     public function xmlSerialize(Writer $writer)
     {
         $writer->write([
@@ -165,6 +184,12 @@ class PaymentMeans implements XmlSerializable
         if ($this->getPayeeFinancialAccount() !== null) {
             $writer->write([
                 Schema::CAC . 'PayeeFinancialAccount' => $this->getPayeeFinancialAccount()
+            ]);
+        }
+
+        if ($this->getPaymentMandate() !== null) {
+            $writer->write([
+                Schema::CAC . 'PaymentMandate' => $this->getPaymentMandate()
             ]);
         }
     }


### PR DESCRIPTION
previously Ubl Version ID had a default value of 2.1, but new rules imply not have this field, with this pull request, we make this field as non required